### PR TITLE
fix: 🐛 added support to load analytics based on user orgunit

### DIFF
--- a/src/app/core/services/analytics/analytics.service.ts
+++ b/src/app/core/services/analytics/analytics.service.ts
@@ -12,7 +12,7 @@ export class AnalyticsService {
   getCascadeAnalytics(): Observable<Analytics> {
     const data = `xXrwhpYL4UD;itIVeB2QV3B;Zq7AbV0d2SS;BHUTFEEteC8`;
     const period = `LAST_QUARTER`;
-    const orgUnit = `m0frOspS7JY`;
+    const orgUnit = `USER_ORGUNIT`;
     const urlMetadata = `displayProperty=NAME&skipMeta=false&includeNumDen=false`;
     const analyticsURL = `analytics?dimension=dx:${data}&dimension=pe:${period}&filter=ou:${orgUnit}&${urlMetadata}`;
     return this.httpClient.get(analyticsURL);

--- a/src/app/pages/home/pages/home/home.component.ts
+++ b/src/app/pages/home/pages/home/home.component.ts
@@ -76,10 +76,6 @@ export class HomeComponent implements OnInit {
     this.progressMSG =
       'Cascade Analysis to Quantify Progress and Gaps towards the 90-90-90 Targets';
 
-    this.hasError$.subscribe((hasError => console.log('HAS ERROR::: ', hasError)));
-    this.error$.subscribe((err => console.log('HAS ERROR::: ', err)));
-
-
     this.favorite$.subscribe((favorite: Favorite) => {
       if (favorite) {
         this.renderId = favorite.id;


### PR DESCRIPTION
This commit will add support to load cascade analytics data based on
user organization unit